### PR TITLE
Note: Make the body scrollable

### DIFF
--- a/src/android/app/src/main/kotlin/com/nivisi/leafy_launcher/MainActivity.kt
+++ b/src/android/app/src/main/kotlin/com/nivisi/leafy_launcher/MainActivity.kt
@@ -234,33 +234,6 @@ class MainActivity: FlutterActivity() {
         registerApplicationChannel(flutterEngine)
     }
 
-    override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
-        @Suppress("DEPRECATION")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            window.insetsController?.hide(WindowInsets.Type.statusBars())
-        } else {
-            window.setFlags(
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN
-            )
-        }
-
-        return super.onCreateView(name, context, attrs)
-    }
-
-    override fun onCreateView(parent: View?, name: String, context: Context, attrs: AttributeSet): View? {
-        @Suppress("DEPRECATION")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            window.insetsController?.hide(WindowInsets.Type.statusBars())
-        } else {
-            window.setFlags(
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN
-            )
-        }
-        return super.onCreateView(parent, name, context, attrs)
-    }
-
     override fun onNewIntent(intent: Intent) {
         if (intent.action == Intent.ACTION_MAIN) {
             homeEventStreamHandler.dispatch()

--- a/src/lib/leafy_launcher.dart
+++ b/src/lib/leafy_launcher.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
-import 'package:leafy_launcher/leafy_overlay_watcher.dart';
+import 'package:leafy_launcher/leafy_system_overlay_observer.dart';
 import 'package:leafy_launcher/module/home_notes/notes/folders/home_note_folders_page.dart';
 import 'package:leafy_launcher/module/home_notes/notes/note/home_note_page.dart';
 import 'package:leafy_launcher/module/home_notes/notes/notes/home_notes_page.dart';
@@ -83,7 +83,7 @@ class LeafyLauncher {
     await initPrimaryDependencies();
     initSecondaryDependencies();
 
-    LeafyOverlayWatcher.configure();
+    LeafySystemOverlayObserver.configure();
 
     LeafyTheme.restoreThemeStyle();
 

--- a/src/lib/leafy_launcher.dart
+++ b/src/lib/leafy_launcher.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
+import 'package:leafy_launcher/leafy_overlay_watcher.dart';
 import 'package:leafy_launcher/module/home_notes/notes/folders/home_note_folders_page.dart';
 import 'package:leafy_launcher/module/home_notes/notes/note/home_note_page.dart';
 import 'package:leafy_launcher/module/home_notes/notes/notes/home_notes_page.dart';
@@ -81,6 +82,8 @@ class LeafyLauncher {
   static Future run() async {
     await initPrimaryDependencies();
     initSecondaryDependencies();
+
+    LeafyOverlayWatcher.configure();
 
     LeafyTheme.restoreThemeStyle();
 

--- a/src/lib/leafy_overlay_watcher.dart
+++ b/src/lib/leafy_overlay_watcher.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/services.dart';
+
+class LeafyOverlayWatcher {
+  static bool _isEnabled = false;
+
+  static void _showTopOverlay() {
+    SystemChrome.setEnabledSystemUIMode(
+      SystemUiMode.manual,
+      overlays: [SystemUiOverlay.bottom, SystemUiOverlay.top],
+    );
+  }
+
+  static void _hideTopOverlay() {
+    SystemChrome.setEnabledSystemUIMode(
+      SystemUiMode.manual,
+      overlays: [SystemUiOverlay.bottom],
+    );
+  }
+
+  static void enable() {
+    _isEnabled = true;
+
+    _hideTopOverlay();
+  }
+
+  static void disable() {
+    _isEnabled = false;
+
+    _showTopOverlay();
+  }
+
+  static void configure() {
+    enable();
+
+    _hideTopOverlay();
+
+    SystemChrome.setSystemUIChangeCallback(
+      (systemOverlaysAreVisible) async {
+        if (systemOverlaysAreVisible) {
+          return;
+        }
+
+        await Future.delayed(const Duration(seconds: 2));
+
+        if (!_isEnabled) {
+          return;
+        }
+
+        _hideTopOverlay();
+      },
+    );
+  }
+}

--- a/src/lib/leafy_system_overlay_observer.dart
+++ b/src/lib/leafy_system_overlay_observer.dart
@@ -40,11 +40,11 @@ class LeafySystemOverlayObserver {
           return;
         }
 
-        await Future.delayed(const Duration(seconds: 2));
-
         if (!_isEnabled) {
           return;
         }
+
+        await Future.delayed(const Duration(seconds: 2));
 
         _hideTopOverlay();
       },

--- a/src/lib/leafy_system_overlay_observer.dart
+++ b/src/lib/leafy_system_overlay_observer.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/services.dart';
 
-class LeafyOverlayWatcher {
+class LeafySystemOverlayObserver {
   static bool _isEnabled = false;
 
   static void _showTopOverlay() {

--- a/src/lib/module/home_notes/notes/folders/home_note_folders_controller.dart
+++ b/src/lib/module/home_notes/notes/folders/home_note_folders_controller.dart
@@ -9,7 +9,7 @@ import 'package:leafy_launcher/resources/theme/home_theme.dart';
 import 'package:leafy_launcher/utils/dialogs/input/input_dialog.dart';
 
 import '../../../../app_routes.dart';
-import '../../../../leafy_overlay_watcher.dart';
+import '../../../../leafy_system_overlay_observer.dart';
 
 class HomeNoteFoldersController extends StatusControllerBase {
   late final FolderRepository _folderRepo = Get.find<FolderRepository>();
@@ -23,7 +23,7 @@ class HomeNoteFoldersController extends StatusControllerBase {
   Future load() async {
     await super.load();
 
-    LeafyOverlayWatcher.disable();
+    LeafySystemOverlayObserver.disable();
 
     scrollController = ScrollController();
 
@@ -87,7 +87,7 @@ class HomeNoteFoldersController extends StatusControllerBase {
 
   @override
   void onClose() {
-    LeafyOverlayWatcher.enable();
+    LeafySystemOverlayObserver.enable();
     super.onClose();
   }
 }

--- a/src/lib/module/home_notes/notes/folders/home_note_folders_controller.dart
+++ b/src/lib/module/home_notes/notes/folders/home_note_folders_controller.dart
@@ -9,6 +9,7 @@ import 'package:leafy_launcher/resources/theme/home_theme.dart';
 import 'package:leafy_launcher/utils/dialogs/input/input_dialog.dart';
 
 import '../../../../app_routes.dart';
+import '../../../../leafy_overlay_watcher.dart';
 
 class HomeNoteFoldersController extends StatusControllerBase {
   late final FolderRepository _folderRepo = Get.find<FolderRepository>();
@@ -21,6 +22,8 @@ class HomeNoteFoldersController extends StatusControllerBase {
   @override
   Future load() async {
     await super.load();
+
+    LeafyOverlayWatcher.disable();
 
     scrollController = ScrollController();
 
@@ -80,5 +83,11 @@ class HomeNoteFoldersController extends StatusControllerBase {
     } on Exception catch (e, s) {
       logger.e('Unable to remove a folder', e, s);
     }
+  }
+
+  @override
+  void onClose() {
+    LeafyOverlayWatcher.enable();
+    super.onClose();
   }
 }

--- a/src/lib/module/home_notes/notes/folders/widget/title/home_note_folders_title.dart
+++ b/src/lib/module/home_notes/notes/folders/widget/title/home_note_folders_title.dart
@@ -28,7 +28,7 @@ class HomeNoteFoldersTitle
         ),
         padding: const EdgeInsets.fromLTRB(
           HomeNoteFoldersPage.horizontalPadding,
-          kHomeVerticalPadding,
+          kHomeVerticalPadding - kStatusBarPadding,
           HomeNoteFoldersPage.horizontalPadding,
           kHomeVerticalPadding / 2.0,
         ),

--- a/src/lib/module/home_notes/notes/note/widget/title/home_note_title.dart
+++ b/src/lib/module/home_notes/notes/note/widget/title/home_note_title.dart
@@ -22,7 +22,7 @@ class HomeNoteTitle extends ThemedGetWidget<HomeNoteController, HomeTheme> {
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         HomeNoteFoldersPage.horizontalPadding,
-        kHomeVerticalPadding,
+        kHomeVerticalPadding - kStatusBarPadding,
         HomeNoteFoldersPage.horizontalPadding,
         kHomeVerticalPadding / 2.0,
       ),

--- a/src/lib/module/home_notes/notes/notes/home_notes_page.dart
+++ b/src/lib/module/home_notes/notes/notes/home_notes_page.dart
@@ -17,9 +17,6 @@ class HomeNotesPage extends StatusPageBase<HomeNotesController, HomeTheme> {
   static const horizontalPadding = kDefaultPadding * 1.5;
 
   @override
-  bool get resizeToAvoidBottomInset => false;
-
-  @override
   Widget ready(BuildContext context, LeafyTheme theme) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/src/lib/module/home_notes/notes/notes/widget/title/home_notes_title.dart
+++ b/src/lib/module/home_notes/notes/notes/widget/title/home_notes_title.dart
@@ -28,7 +28,7 @@ class HomeNotesTitle extends ThemedGetWidget<HomeNotesController, HomeTheme> {
         ),
         padding: const EdgeInsets.fromLTRB(
           HomeNoteFoldersPage.horizontalPadding,
-          kHomeVerticalPadding,
+          kHomeVerticalPadding - kStatusBarPadding,
           HomeNoteFoldersPage.horizontalPadding,
           kHomeVerticalPadding / 2.0,
         ),

--- a/src/lib/resources/app_constants.dart
+++ b/src/lib/resources/app_constants.dart
@@ -9,6 +9,7 @@ const kDefaultPadding = 10.0;
 
 const kHomeHorizontalPadding = kDefaultPadding * 2.5;
 const kHomeVerticalPadding = kDefaultPadding * 4.0;
+const kStatusBarPadding = 20.0;
 const kHomeAppsSpacingMultipler = 2.0;
 const kHomeHorizontalSwipeIconSize = 55.0;
 const kHomeCornerButtonEdgeInsets = EdgeInsets.only(


### PR DESCRIPTION
Resolves #120 

Fullscreen on Android breaks the keyboard resizing (https://github.com/flutter/flutter/issues/59397). So here is a workaround for this:
- Fullscreen mode is removed;
- `LeafySystemOverlayObserver` was inroduced to:
- - Hide the top system overlay by default;
- - Show it on the notes module.