### PR TITLE
Notes: Title Back button is delayed

### DIFF
--- a/src/lib/module/home_notes/notes/notes/widget/title/home_notes_title.dart
+++ b/src/lib/module/home_notes/notes/notes/widget/title/home_notes_title.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:leafy_launcher/database/leafy_notes_db/leafy_notes_database.dart';
 import 'package:leafy_launcher/module/home_notes/notes/folders/home_note_folders_page.dart';
 import 'package:leafy_launcher/module/home_notes/notes/notes/home_notes_controller.dart';

--- a/src/lib/module/home_notes/notes/notes/widget/title/home_notes_title.dart
+++ b/src/lib/module/home_notes/notes/notes/widget/title/home_notes_title.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:leafy_launcher/database/leafy_notes_db/leafy_notes_database.dart';
 import 'package:leafy_launcher/module/home_notes/notes/folders/home_note_folders_page.dart';
 import 'package:leafy_launcher/module/home_notes/notes/notes/home_notes_controller.dart';
@@ -18,7 +19,6 @@ class HomeNotesTitle extends ThemedGetWidget<HomeNotesController, HomeTheme> {
   Widget body(BuildContext context, LeafyTheme theme) {
     return GestureDetector(
       onTap: controller.onTitleTapped,
-      onDoubleTap: controller.onTitleDoubleTapped,
       child: Container(
         decoration: BoxDecoration(
           color: Colors.transparent,
@@ -57,9 +57,13 @@ class HomeNotesTitle extends ThemedGetWidget<HomeNotesController, HomeTheme> {
 
                 final folder = snapshot.data!;
 
-                return Text(
-                  folder.title,
-                  style: theme.bodyText1.copyWith(fontWeight: FontWeight.w500),
+                return GestureDetector(
+                  onDoubleTap: controller.onTitleDoubleTapped,
+                  child: Text(
+                    folder.title,
+                    style:
+                        theme.bodyText1.copyWith(fontWeight: FontWeight.w500),
+                  ),
                 );
               },
             ),


### PR DESCRIPTION
Resolves #113 

The reason is that the outer gesture detector awaited for the second tap (onDoubleTap handler) and didn't release the default tap handler.